### PR TITLE
TEMPFIX autoscaler provision issue in china region

### DIFF
--- a/templates/amazon-eks-cluster-autoscaler.template.yaml
+++ b/templates/amazon-eks-cluster-autoscaler.template.yaml
@@ -23,6 +23,8 @@ Conditions:
   NeedsStaticList: !Or
     - !Equals [!Ref 'AWS::Region', 'af-south-1']
     - !Equals [!Ref 'AWS::Region', 'eu-south-1']
+    - !Equals [!Ref 'AWS::Region', 'cn-north-1']
+    - !Equals [!Ref 'AWS::Region', 'cn-northwest-1']
 Mappings:
   Config:
     Prefix: { Value: 'eks-quickstart' }


### PR DESCRIPTION
[issue](https://github.com/kubernetes/autoscaler/issues/3276)
[tempory fix](https://github.com/kubernetes/autoscaler/issues/3076) is set aws-use-static-instance-list = true